### PR TITLE
feat(rustdesk): add self-hosted RustDesk server deployment

### DIFF
--- a/kubernetes/apps/rustdesk/kustomization.yaml
+++ b/kubernetes/apps/rustdesk/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: rustdesk
+components:
+  - ../../components/common
+resources:
+  - ./rustdesk-server/ks.yaml

--- a/kubernetes/apps/rustdesk/rustdesk-server/app/helmrelease.yaml
+++ b/kubernetes/apps/rustdesk/rustdesk-server/app/helmrelease.yaml
@@ -1,0 +1,95 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/refs/heads/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ${APP}
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      main:
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          hbbs:
+            image:
+              # renovate: datasource=docker depName=rustdesk/rustdesk-server
+              repository: rustdesk/rustdesk-server
+              tag: 1.1.15
+            command: ["hbbs"]
+            args: ["-r", "192.168.2.5:21117", "-k", "_"]
+            ports:
+              - containerPort: 21115
+                protocol: TCP
+              - containerPort: 21116
+                protocol: TCP
+              - containerPort: 21116
+                protocol: UDP
+              - containerPort: 21118
+                protocol: TCP
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+          hbbr:
+            image:
+              # renovate: datasource=docker depName=rustdesk/rustdesk-server
+              repository: rustdesk/rustdesk-server
+              tag: 1.1.15
+            command: ["hbbr"]
+            args: ["-k", "_"]
+            ports:
+              - containerPort: 21117
+                protocol: TCP
+              - containerPort: 21119
+                protocol: TCP
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+    service:
+      main:
+        type: LoadBalancer
+        loadBalancerIP: 192.168.2.5
+        ports:
+          hbbs-nat:
+            port: 21115
+            protocol: TCP
+            targetPort: 21115
+          hbbs-tcp:
+            port: 21116
+            protocol: TCP
+            targetPort: 21116
+          hbbs-udp:
+            port: 21116
+            protocol: UDP
+            targetPort: 21116
+          hbbr:
+            port: 21117
+            protocol: TCP
+            targetPort: 21117
+    persistence:
+      data:
+        type: persistentVolumeClaim
+        existingClaim: rustdesk-data
+        globalMounts:
+          - path: /root

--- a/kubernetes/apps/rustdesk/rustdesk-server/app/kustomization.yaml
+++ b/kubernetes/apps/rustdesk/rustdesk-server/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - volumes.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/rustdesk/rustdesk-server/app/volumes.yaml
+++ b/kubernetes/apps/rustdesk/rustdesk-server/app/volumes.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rustdesk-data
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: iscsi

--- a/kubernetes/apps/rustdesk/rustdesk-server/ks.yaml
+++ b/kubernetes/apps/rustdesk/rustdesk-server/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rustdesk-server
+  namespace: &namespace rustdesk
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/rustdesk/rustdesk-server/app
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  dependsOn:
+    - name: democratic-csi
+      namespace: system
+  postBuild:
+    substitute:
+      APP: *app
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  wait: false
+  interval: 30m
+  timeout: 5m


### PR DESCRIPTION
## Summary

- Add RustDesk server (hbbs + hbbr) to a new `rustdesk` namespace using the app-template helm chart
- Both containers share a 1Gi persistent volume at `/root` for identity keys (`id_ed25519`)
- LoadBalancer service at `192.168.2.5` exposes ports 21115, 21116 (TCP+UDP), and 21117

## Test plan

- [x] Verify Flux reconciles the new `rustdesk-server` Kustomization without errors
- [x] Confirm the pod starts with both `hbbs` and `hbbr` containers running
- [x] Check that `id_ed25519.pub` is generated in the persistent volume
- [x] Test RustDesk client connectivity using the LoadBalancer IP and public key

Made with [Cursor](https://cursor.com)